### PR TITLE
Improved lines() function

### DIFF
--- a/README.md
+++ b/README.md
@@ -762,8 +762,12 @@ Alternative to `wc -l`.
 ```sh
 lines() {
     # Usage lines "file"
-    mapfile -tn 0 lines < "$1"
-    printf '%s\n' "${#lines[@]}"
+    local count
+    count=0
+    while IFS= read -r line; do
+        ((count++))
+    done < "$1"
+    printf "%s\n" "$count"
 }
 ```
 

--- a/README.md
+++ b/README.md
@@ -767,7 +767,7 @@ lines() {
     while IFS= read -r line; do
         ((count++))
     done < "$1"
-    printf "%s\n" "$count"
+    printf '%s\n' "$count"
 }
 ```
 


### PR DESCRIPTION
The existing implementation of the `lines()` function may be impractical in some scenarios. Its use of `mapfile` requires reading the entire file into memory before counting the number of lines. While this will be fine with smaller files, it could be a problem when used on larger files on systems with limited memory.

I have replaced it with an implementation that uses a `while` loop so that only a single line is stored in memory at a time.

Relevant link: [How can I read a file (data stream, variable) line-by-line (and/or field-by-field)?](http://mywiki.wooledge.org/BashFAQ/001)
