### PR TITLE
Add note about Bash on Windows 10 for $OSTYPE

### DIFF
--- a/README.md
+++ b/README.md
@@ -1196,6 +1196,17 @@ Systems without needing to call `uname`.
 
 ```shell
 "$OSTYPE"
+
+# NOTE: $OSTYPE will return 'linux' when using Bash on Windows 10.
+# In this instance, you can check /proc/version instead.
+
+file="/proc/version"
+if [ -f "$file" ]; then
+  file_data="$(<"$file")"
+  if [[ "$file_data" == *Microsoft* ]] || [[ "$file_data" == *WSL* ]]; then
+      os="Windows"
+  fi
+fi
 ```
 
 ## Get the current working directory.


### PR DESCRIPTION
I noticed the comment about this repo not including error handling, and this is probably overkill anyway!
I just found it to be an interesting edge case, and was exited to try out `<"$file"` 😂

Logic from [here](https://stackoverflow.com/a/43618657).
Simulated on MacOS with file information from [here](https://stackoverflow.com/a/39627591).