### PR TITLE
Added background commands

### DIFF
--- a/README.md
+++ b/README.md
@@ -152,6 +152,7 @@ See something that is incorrectly described, buggy or outright wrong? Open an is
     * [Get the list of functions in a script](#get-the-list-of-functions-in-a-script)
     * [Bypass shell aliases](#bypass-shell-aliases)
     * [Bypass shell functions](#bypass-shell-functions)
+    * [Run a command in the background](#run-a-command-in-the-background)
 * [AFTERWORD](#afterword)
 
 <!-- vim-markdown-toc -->
@@ -1976,6 +1977,18 @@ ls
 
 # command
 command ls
+```
+
+## Run a command in the background
+
+This will run the given command and keep it running, even after the terminal or SSH connection is terminated. All output is ignored.
+
+```sh
+bkr() {
+    (nohup "$@" &>/dev/null &)
+}
+
+bkr ./some_script.sh # some_script.sh is now running in the background
 ```
 
 <!-- CHAPTER END -->

--- a/manuscript/chapter1.txt
+++ b/manuscript/chapter1.txt
@@ -366,7 +366,7 @@ if [[ "$var" == *sub_string ]]; then
     printf '%s\n' "var ends with sub_string."
 fi
 
-# Inverse (var does not start with sub_string).
+# Inverse (var does not end with sub_string).
 if [[ "$var" != *sub_string ]]; then
     printf '%s\n' "var does not end with sub_string."
 fi

--- a/manuscript/chapter10.txt
+++ b/manuscript/chapter10.txt
@@ -32,8 +32,8 @@
 | Expression | What does it do? |
 | ---------- | ---------------- |
 | `file -ef file2` | If both files refer to the same inode and device numbers.
-| `file -nt file2` | If `file` is newer than `file2` (*uses modification ime*) or `file` exists and `file2` does not.
-| `file -ot file2` | If `file` is older than `file2` (*uses modification ime*) or `file2` exists and `file` does not.
+| `file -nt file2` | If `file` is newer than `file2` (*uses modification time*) or `file` exists and `file2` does not.
+| `file -ot file2` | If `file` is older than `file2` (*uses modification time*) or `file2` exists and `file` does not.
 
 ## Variable Conditionals
 

--- a/manuscript/chapter19.txt
+++ b/manuscript/chapter19.txt
@@ -186,5 +186,16 @@ ls
 command ls
 ```
 
-<!-- CHAPTER END -->
+## Run a command in the background
 
+This will run the given command and keep it running even after the terminal is closed.
+
+```sh
+bkr() {
+    (nohup "$@" &>/dev/null &)
+}
+
+bkr ./some_script.sh # some_script.sh is now running in the background
+```
+
+<!-- CHAPTER END -->

--- a/manuscript/chapter19.txt
+++ b/manuscript/chapter19.txt
@@ -188,7 +188,7 @@ command ls
 
 ## Run a command in the background
 
-This will run the given command and keep it running even after the terminal is closed.
+This will run the given command and keep it running, even after the terminal or SSH connection is terminated. All output is ignored.
 
 ```sh
 bkr() {
@@ -199,3 +199,4 @@ bkr ./some_script.sh # some_script.sh is now running in the background
 ```
 
 <!-- CHAPTER END -->
+


### PR DESCRIPTION
The syntax looks ugly, but this is the optimal way to do it. It doesn't have any extraneous output due to the parenthesis surrounding the command, and also sends error output to /dev/null.