### PR TITLE
Add reverse case function

### DIFF
--- a/README.md
+++ b/README.md
@@ -386,6 +386,32 @@ $ upper "HELLO"
 HELLO
 ```
 
+## Reverse a string case
+
+**CAVEAT:** Requires `bash` 4+
+
+**Example Function:**
+
+```sh
+reverse_case() {
+    # Usage: reverse_case "string"
+    printf '%s\n' "${1~~}"
+}
+```
+
+**Example Usage:**
+
+```shell
+$ reverse_case "hello"
+HELLO
+
+$ reverse_case "HeLlO"
+hElLo
+
+$ reverse_case "HELLO"
+hello
+```
+
 ## Trim quotes from a string
 
 **Example Function:**
@@ -1221,6 +1247,8 @@ Contrary to popular belief, there is no issue in utilizing raw escape sequences.
 | `${VAR^^}` | Uppercase all characters. | `bash 4+` |
 | `${VAR,}` | Lowercase first character. | `bash 4+` |
 | `${VAR,,}` | Lowercase all characters. | `bash 4+` |
+| `${VAR~}` | Reverse case of first character. | `bash 4+` |
+| `${VAR~~}` | Reverse case of all characters. | `bash 4+` |
 
 
 ## Default Value

--- a/manuscript/chapter1.txt
+++ b/manuscript/chapter1.txt
@@ -209,6 +209,32 @@ $ upper "HELLO"
 HELLO
 ```
 
+## Reverse a string case
+
+**CAVEAT:** Requires `bash` 4+
+
+**Example Function:**
+
+```sh
+reverse_case() {
+    # Usage: reverse_case "string"
+    printf '%s\n' "${1~~}"
+}
+```
+
+**Example Usage:**
+
+```shell
+$ reverse_case "hello"
+HELLO
+
+$ reverse_case "HeLlO"
+hElLo
+
+$ reverse_case "HELLO"
+hello
+```
+
 ## Trim quotes from a string
 
 **Example Function:**

--- a/manuscript/chapter8.txt
+++ b/manuscript/chapter8.txt
@@ -48,6 +48,8 @@
 | `${VAR^^}` | Uppercase all characters. | `bash 4+` |
 | `${VAR,}` | Lowercase first character. | `bash 4+` |
 | `${VAR,,}` | Lowercase all characters. | `bash 4+` |
+| `${VAR~}` | Reverse case of first character. | `bash 4+` |
+| `${VAR~~}` | Reverse case of all characters. | `bash 4+` |
 
 
 ## Default Value

--- a/test.sh
+++ b/test.sh
@@ -28,6 +28,11 @@ test_upper() {
     assert_equals "$result" "HELLO"
 }
 
+test_reverse_case() {
+    result="$(reverse_case "HeLlO")"
+    assert_equals "$result" "hElLo"
+}
+
 test_trim_quotes() {
     result="$(trim_quotes "\"te'st' 'str'ing\"")"
     assert_equals "$result" "test string"


### PR DESCRIPTION
This is an undocument feature that allows reversing a case of a variable in the same way as it `,` and `^` do.