### PR TITLE
Separate code from example

### DIFF
--- a/manuscript/chapter19.txt
+++ b/manuscript/chapter19.txt
@@ -219,7 +219,9 @@ This will run the given command and keep it running, even after the terminal or 
 bkr() {
     (nohup "$@" &>/dev/null &)
 }
+```
 
+```shell
 bkr ./some_script.sh # some_script.sh is now running in the background
 ```
 


### PR DESCRIPTION
As [test.sh](https://github.com/dylanaraps/pure-bash-bible/blob/f0788ed4b0a591d59a468090fc24e7657120dedc/test.sh#L227) is including
```
bkr ./some_script.sh 
```
in the `readme_code` file.