### PR TITLE
Fix for exported functions (declare -fx)

### DIFF
--- a/README.md
+++ b/README.md
@@ -2132,7 +2132,8 @@ printf '\n'
 get_functions() {
     # Usage: get_functions
     IFS=$'\n' read -d "" -ra functions < <(declare -F)
-    printf '%s\n' "${functions[@]//declare -f }"
+    functions=("${functions[@]#* }")
+    printf '%s\n' "${functions[@]#* }"
 }
 ```
 


### PR DESCRIPTION
The current logic fails if a function is exported, i.e., `declare -fx funcname`