### PR TITLE
using mapfile instead of read ( require v4 bash )

### DIFF
--- a/README.md
+++ b/README.md
@@ -308,7 +308,7 @@ This is an alternative to `cut`, `awk` and other tools.
 ```sh
 split() {
    # Usage: split "string" "delimiter"
-   IFS=$'\n' read -d "" -ra arr <<< "${1//$2/$'\n'}"
+   mapfile -t arr <<< "${1//$2/$'\n'}"
    printf '%s\n' "${arr[@]}"
 }
 ```


### PR DESCRIPTION
So, first off this seems like a really awesome project :slightly_smiling_face:  I love me some bash :grin:. So, thank you for making this. One of my friends linked to it for something they were doing :slightly_smiling_face: 

Maybe there is another reason that you didn't use mapfile before, but since you are requiring v4+ anyways ( and mapfile was released in [v4](https://tldp.org/LDP/abs/html/bashver4.html)). Then I think this is a slightly less complex version of the same command. Maybe you were trying to be a bit more explicit for visual understanding of how things get split up ( setting IFS and everything ), but I get the same output when I run those example commands.

```shell
$ split() { mapfile -t arr <<< "${1//$2/$'\n'}";    printf '%s\n' "${arr[@]}"; }
$ split "apples,oranges,pears,grapes" ","
apples
oranges
pears
grapes
$ split "1, 2, 3, 4, 5" ", "
1
2
3
4
5
```
Let me know if there is anything I can do to help :slightly_smiling_face: or if there is anything else I need to add ( tests, etc... ).
I look forward to looking more into this pure bash bible :grin: 
